### PR TITLE
Fill keycode to RimeKeyMapping

### DIFF
--- a/codegen/src/main/java/com/osfans/trime/codegen/GenKeyMapping.kt
+++ b/codegen/src/main/java/com/osfans/trime/codegen/GenKeyMapping.kt
@@ -36,12 +36,12 @@ internal class GenKeyMappingProcessor(private val environment: SymbolProcessorEn
 
     private val pairs: List<KeyPair> = listOf(
         "space" to 0x0020 to "KEYCODE_SPACE", /* U+0020 SPACE */
-//            0x0021 to KeyEvent.KEYCODE_EXCLAM, /* U+0021 EXCLAMATION MARK */
-//            0x0022 to KeyEvent.KEYCODE_QUOTEDBL, /* U+0022 QUOTATION MARK */
+        "exclam" to 0x0021 to KeyEvent.KEYCODE_EXCLAM, /* U+0021 EXCLAMATION MARK */
+        "quotedbl" to 0x0022 to KeyEvent.KEYCODE_QUOTEDBL, /* U+0022 QUOTATION MARK */
         "numbersign" to 0x0023 to "KEYCODE_POUND", /* U+0023 NUMBER SIGN */
-//            0x0024 to KeyEvent.KEYCODE_DOLLAR, /* U+0024 DOLLAR SIGN */
-//            0x0025 to KeyEvent.KEYCODE_PERCENT, /* U+0025 PERCENT SIGN */
-//            0x0026 to KeyEvent.KEYCODE_AMPERSAND, /* U+0026 AMPERSAND */
+        "dollar" to 0x0024 to KeyEvent.KEYCODE_DOLLAR, /* U+0024 DOLLAR SIGN */
+        "percent" to 0x0025 to KeyEvent.KEYCODE_PERCENT, /* U+0025 PERCENT SIGN */
+        "ampersand" to 0x0026 to KeyEvent.KEYCODE_AMPERSAND, /* U+0026 AMPERSAND */
         "apostrophe" to 0x0027 to "KEYCODE_APOSTROPHE", /* U+0027 APOSTROPHE */
 //            0x0027 to KeyEvent.KEYCODE_QUOTERIGHT, /* deprecated */
 //            0x0028 to KeyEvent.KEYCODE_PARENLEFT, /* U+0028 LEFT PARENTHESIS */
@@ -62,12 +62,12 @@ internal class GenKeyMappingProcessor(private val environment: SymbolProcessorEn
         "7" to 0x0037 to "KEYCODE_7", /* U+0037 DIGIT SEVEN */
         "8" to 0x0038 to "KEYCODE_8", /* U+0038 DIGIT EIGHT */
         "9" to 0x0039 to "KEYCODE_9", /* U+0039 DIGIT NINE */
-//            0x003a to KeyEvent.KEYCODE_COLON, /* U+003A COLON */
+        "PARENTHESIS" to 0x003a to KeyEvent.KEYCODE_COLON, /* U+003A COLON */
         "semicolon" to 0x003b to "KEYCODE_SEMICOLON", /* U+003B SEMICOLON */
-//            0x003c to KeyEvent.KEYCODE_LESS, /* U+003C LESS-THAN SIGN */
+        "less" to 0x003c to KeyEvent.KEYCODE_LESS, /* U+003C LESS-THAN SIGN */
         "equal" to 0x003d to "KEYCODE_EQUALS", /* U+003D EQUALS SIGN */
-//            0x003e to KeyEvent.KEYCODE_GREATER, /* U+003E GREATER-THAN SIGN */
-//            0x003f to KeyEvent.KEYCODE_QUESTION, /* U+003F QUESTION MARK */
+        "greater" to 0x003e to KeyEvent.KEYCODE_GREATER, /* U+003E GREATER-THAN SIGN */
+        "question" to 0x003f to KeyEvent.KEYCODE_QUESTION, /* U+003F QUESTION MARK */
         "at" to 0x0040 to "KEYCODE_AT", /* U+0040 COMMERCIAL AT */
         "A" to 0x0041 to "KEYCODE_A", /* U+0041 LATIN CAPITAL LETTER A */
         "B" to 0x0042 to "KEYCODE_B", /* U+0042 LATIN CAPITAL LETTER B */
@@ -98,8 +98,8 @@ internal class GenKeyMappingProcessor(private val environment: SymbolProcessorEn
         "bracketleft" to 0x005b to "KEYCODE_LEFT_BRACKET", /* U+005B LEFT SQUARE BRACKET */
         "backslash" to 0x005c to "KEYCODE_BACKSLASH", /* U+005C REVERSE SOLIDUS */
         "bracketright" to 0x005d to "KEYCODE_RIGHT_BRACKET", /* U+005D RIGHT SQUARE BRACKET */
-//            0x005e to KeyEvent.KEYCODE_ASCIICIRCUM, /* U+005E CIRCUMFLEX ACCENT */
-//            0x005f to KeyEvent.KEYCODE_UNDERSCORE, /* U+005F LOW LINE */
+        "asciicircum" to 0x005e to KeyEvent.KEYCODE_ASCIICIRCUM, /* U+005E CIRCUMFLEX ACCENT */
+        "underscore" to 0x005f to KeyEvent.KEYCODE_UNDERSCORE, /* U+005F LOW LINE */
         "grave" to 0x0060 to "KEYCODE_GRAVE", /* U+0060 GRAVE ACCENT */
 //            0x0060 to KeyEvent.KEYCODE_QUOTELEFT, /* deprecated */
         "a" to 0x0061 to "KEYCODE_A", /* U+0061 LATIN SMALL LETTER A */
@@ -128,10 +128,10 @@ internal class GenKeyMappingProcessor(private val environment: SymbolProcessorEn
         "x" to 0x0078 to "KEYCODE_X", /* U+0078 LATIN SMALL LETTER X */
         "y" to 0x0079 to "KEYCODE_Y", /* U+0079 LATIN SMALL LETTER Y */
         "z" to 0x007a to "KEYCODE_Z", /* U+007A LATIN SMALL LETTER Z */
-//            0x007b to KeyEvent.KEYCODE_BRACELEFT, /* U+007B LEFT CURLY BRACKET */
-//            0x007c to KeyEvent.KEYCODE_BAR, /* U+007C VERTICAL LINE */
-//            0x007d to KeyEvent.KEYCODE_BRACERIGHT, /* U+007D RIGHT CURLY BRACKET */
-//            0x007e to KeyEvent.KEYCODE_ASCIITILDE, /* U+007E TILDE */
+        "braceleft" to 0x007b to KeyEvent.KEYCODE_BRACELEFT, /* U+007B LEFT CURLY BRACKET */
+        "bar" 0x007c to KeyEvent.KEYCODE_BAR, /* U+007C VERTICAL LINE */
+        "braceright" to 0x007d to KeyEvent.KEYCODE_BRACERIGHT, /* U+007D RIGHT CURLY BRACKET */
+        "asciitilde" to 0x007e to KeyEvent.KEYCODE_ASCIITILDE, /* U+007E TILDE */
 
         "F1" to 0xffbe to "KEYCODE_F1",
         "F2" to 0xffbf to "KEYCODE_F2",


### PR DESCRIPTION
exclam, quotedbl, dollar, percent, ampersand, colon, less, greater, question, asciicircum, underscore, braceleft, bar, braceright, asciitilde

## Pull request

#### Issue tracker
Fixes will automatically close the related issues

Fixes #

#### Feature
Describe features of pull request

#### Code of conduct
- [ ] [CONTRIBUTING](CONTRIBUTING.md)

#### Style lint
- [ ] `make sytle-lint`

#### Build pass
- [ ] `make debug`

#### Manually test
- [ ] Done

#### Code Review
1. No wildcards import
2. Manual build and test pass
3. GitHub action ci pass
4. At least one contributor reviews and votes
5. Can be merged clean without conflicts
6. PR will be merged by rebase upstream base

#### Daily build
Login and download artifact at https://github.com/osfans/trime/actions

#### Additional Info

